### PR TITLE
[#18] Require by file name instead of using File.join

### DIFF
--- a/lib/omniauth-paypal-oauth2.rb
+++ b/lib/omniauth-paypal-oauth2.rb
@@ -1,1 +1,1 @@
-require File.join('omniauth', 'paypal_oauth2')
+require "omniauth/paypal_oauth2"

--- a/lib/omniauth/paypal_oauth2.rb
+++ b/lib/omniauth/paypal_oauth2.rb
@@ -1,1 +1,1 @@
-require File.join('omniauth', 'strategies', 'paypal_oauth2')
+require "omniauth/strategies/paypal_oauth2"


### PR DESCRIPTION
Thank you for putting this gem together! 

### Summary

When configuring the  Rails middleware for this strategy, Rails was unable to find the strategy included in this gem. 

I tried passing in the fully qualified constant instead of using the symbolized name and saw the same outcome. I noticed other OAuth2 gems, like the [Google gem](https://github.com/zquestz/omniauth-google-oauth2/blob/master/lib/omniauth/google_oauth2.rb#L3) used the old fashioned `require "omniauth/xxx/yyy"` approach and it loaded fine. Testing that theory locally I was able to load this strategy on boot.


### Other Information

New rails project was using Rails 5.2.1 / Ruby 2.5.1

Resolves #18 
