### PR TITLE
[#48] Relax json dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     omniauth-paypal-oauth2 (2.0.1)
-      json (~> 2.1)
+      json (>= 1.7, < 3)
       omniauth-oauth2 (~> 1.5)
 
 GEM
@@ -15,10 +15,10 @@ GEM
     hashie (3.6.0)
     jaro_winkler (1.5.3)
     json (2.2.0)
-    jwt (2.1.0)
+    jwt (2.2.1)
     multi_json (1.13.1)
     multi_xml (0.6.0)
-    multipart-post (2.0.0)
+    multipart-post (2.1.1)
     oauth2 (1.4.1)
       faraday (>= 0.8, < 0.16.0)
       jwt (>= 1.0, < 3.0)

--- a/omniauth-paypal-oauth2.gemspec
+++ b/omniauth-paypal-oauth2.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.3'
 
-  gem.add_dependency 'json', '~> 2.1'
+  gem.add_dependency 'json', '>= 1.7', '<3'
   gem.add_dependency 'omniauth-oauth2', '~> 1.5'
 
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
- The dependency on JSON for what it provides this gem is not
  affected by whether it's 1.x or 2.x
- Other omniauth strategies (and older gems in general) depend
  on json 1.7. This lib works just fine with 1.7

**Description**

I relaxed the dependency in the `gemspec` file.

Resolves #48 
